### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You'll need to have a macbook with an up-to-date version of XCode installed.
 
 You can run Android on any platform, including Windows and Linux.
 
-Download [JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) adn [Android studio](https://developer.android.com/studio/index.html) (make sure you install SDK 9 wheen installing Android studio).
+Download [JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) and [Android studio](https://developer.android.com/studio/index.html) (make sure you install SDK 9 wheen installing Android studio).
 
 Then add these variables to your `.bash_profile`:
 


### PR DESCRIPTION
change "adn" to "and"
Hi @lithin! I did your workshop at codebar in May, it was super helpful and very enjoyable!
As I went there after a full day of workshops with a burnt brain, on first read, I thought the typo "adn" was yet another abbreviation of something to download, so I changed it in case you want to use this tutorial again to prevent other burnt brainers' confusion!